### PR TITLE
patch-select-query-builder: add metadata check

### DIFF
--- a/src/patch-select-query-builder.ts
+++ b/src/patch-select-query-builder.ts
@@ -17,7 +17,7 @@ class MySelectQB<Entity extends ObjectLiteral> extends SelectQueryBuilder<Entity
    */
   protected ___patchScopes___(): void {
     const table = this.expressionMap.mainAlias
-    if (!table) return
+    if (!table || !table.hasMetadata) return
     const metadata = table.metadata.tableMetadataArgs as ScopedTableMetadata<Entity>
     if (metadata.scopes && metadata.scopesEnabled) {
       metadata.scopes.forEach(scope => scope(this, table.name))


### PR DESCRIPTION
Adds a `hasMetadata` check before accessing the `table.metadata`. This is needed since the metadata might be undefined in cases where TypeORM generates a `select distinct {alias} from (<query generated from query builder>)`.